### PR TITLE
Add CreationPolicy support.

### DIFF
--- a/agi/template.py
+++ b/agi/template.py
@@ -50,6 +50,7 @@ class Resource(dict):
     def __init__(self, Type,
                  Name=None,
                  DependsOn=None,
+                 CreationPolicy=None,
                  DeletionPolicy=None,
                  UpdatePolicy=None,
                  Metadata=None,
@@ -70,6 +71,7 @@ class Resource(dict):
             filter_pairs(
                 Type=Type,
                 DependsOn=DependsOn,
+                CreationPolicy=CreationPolicy,
                 DeletionPolicy=DeletionPolicy,
                 UpdatePolicy=UpdatePolicy,
                 Metadata=Metadata,

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ from setuptools import setup, find_packages
 
 setup(
     name='agi',
-    version='1.1.1',
+    version='1.2.0',
     packages=find_packages(exclude=['tests'])
 )

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -72,6 +72,7 @@ class TestResource(unittest.TestCase):
             "type",
             Name="name",
             DependsOn="dependson",
+            CreationPolicy="creationpolicy",
             DeletionPolicy="deletionpolicy",
             UpdatePolicy="updatepolicy",
             Metadata="metadata",
@@ -90,6 +91,9 @@ class TestResource(unittest.TestCase):
 
     def test_depends_on(self):
         self.assertEqual("dependson", self.resource["DependsOn"])
+
+    def test_creation_policy(self):
+        self.assertEqual("creationpolicy", self.resource["CreationPolicy"])
 
     def test_deletion_policy(self):
         self.assertEqual("deletionpolicy", self.resource["DeletionPolicy"])


### PR DESCRIPTION
This is part of the new `SignalResource` system: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-creationpolicy.html

cc @whilp @tomwans
